### PR TITLE
fix issue with maze generation

### DIFF
--- a/src/MazeGrid.jsx
+++ b/src/MazeGrid.jsx
@@ -24,8 +24,8 @@ export default function MazeGrid({ width = 10, height = 10 }) {
               return cell === "end" ? "end" : "visited";
             }
             return cell;
-          }),
-        ),
+          })
+        )
       );
       if (maze[y][x] === "end") {
         console.log("path found!");
@@ -89,8 +89,8 @@ export default function MazeGrid({ width = 10, height = 10 }) {
               return cell === "end" ? "end" : "visited";
             }
             return cell;
-          }),
-        ),
+          })
+        )
       );
 
       if (maze[y][x] === "end") {
@@ -171,7 +171,7 @@ export default function MazeGrid({ width = 10, height = 10 }) {
     function carvePath(x, y) {
       matrix[y][x] = "path";
 
-      const directions = dirs.sort(() => Math.random() - 0.5);
+      const directions = [...dirs].sort(() => Math.random() - 0.5);
 
       for (let [dx, dy] of directions) {
         const nx = x + dx * 2;


### PR DESCRIPTION
GenarateMaze function had an issue with carving a path, since using sort mutates the original array, it happens that from node we go in the same direction twice, hence some directions are never explored and the maze could look like this 
![image](https://github.com/user-attachments/assets/770209fe-5891-4be0-84e6-f5961b0a215c)
